### PR TITLE
fix typo in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://book.getfoundry.sh/
 ### Install
 
 ```shell
-$ forge soldeer install
+$ forge install
 ```
 
 ### Build


### PR DESCRIPTION
This PR corrects a typo in the Foundry installation command. The original command contained `soldeer`, which is a misspelling of `install`. This change ensures that the correct command is used when setting up Foundry, improving clarity and functionality.